### PR TITLE
Add PredicateFilter

### DIFF
--- a/src/GeoStatsBase.jl
+++ b/src/GeoStatsBase.jl
@@ -297,6 +297,7 @@ export
   # filtering
   AbstractFilter,
   UniqueCoordsFilter,
+  PredicateFilter,
 
   # trends
   polymat,

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -20,3 +20,4 @@ function filter end
 # IMPLEMENTATIONS
 # ----------------
 include("filtering/unique_coords.jl")
+include("filtering/predicate.jl")

--- a/src/filtering/predicate.jl
+++ b/src/filtering/predicate.jl
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------
+# Licensed under the ISC License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    PredicateFilter(pred)
+
+A filter method that retains all locations according to
+a predicate function `pred`. A predicate function takes
+samples as input, e.g. `pred(s) = s.precipitation > 100`.
+"""
+struct PredicateFilter <: AbstractFilter
+  pred::Function
+end
+
+function filter(sdata, filt::PredicateFilter)
+  𝒯 = values(sdata)
+  𝒟 = domain(sdata)
+
+  # use row table view
+  ctor = Tables.materializer(𝒯)
+  rows = Tables.rowtable(𝒯)
+
+  # locations to retain
+  locs = findall(filt.pred, rows)
+
+  # return point set
+  table = ctor(rows[locs])
+  coord = coordinates(𝒟, locs)
+
+  georef(table, coord)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -81,6 +81,15 @@ join(sdata₁::AbstractData, sdata₂::AbstractData) =
   join(sdata₁, sdata₂, VariableJoiner())
 
 """
+    filter(pred, sdata)
+
+Filter spatial data `sdata` using predicate function `pred`.
+
+See [`PredicateFilter`](@ref) for more details.
+"""
+filter(pred, sdata::AbstractData) = filter(sdata, PredicateFilter(pred))
+
+"""
     uniquecoords(sdata; agg=Dict())
 
 Filter spatial data `sdata` to produce a new data

--- a/test/filtering.jl
+++ b/test/filtering.jl
@@ -10,4 +10,20 @@
     ndata = filter(sdata, UniqueCoordsFilter())
     @test npoints(ndata) == 100
   end
+
+  @testset "PredicateFilter" begin
+    𝒟 = georef((a=[1,2,3],b=[3,2,1]))
+    𝒫ₐ = filter(𝒟, PredicateFilter(s -> s.a > 1))
+    𝒫ᵦ = filter(𝒟, PredicateFilter(s -> s.b > 1))
+    𝒫ₐᵦ = filter(𝒟, PredicateFilter(s -> s.a > 1 && s.b > 1))
+    @test npoints(𝒫ₐ) == 2
+    @test npoints(𝒫ᵦ) == 2
+    @test npoints(𝒫ₐᵦ) == 1
+    @test 𝒫ₐ[:a] == [2,3]
+    @test 𝒫ₐ[:b] == [2,1]
+    @test 𝒫ᵦ[:a] == [1,2]
+    @test 𝒫ᵦ[:b] == [3,2]
+    @test 𝒫ₐᵦ[:a] == [2]
+    @test 𝒫ₐᵦ[:b] == [2]
+  end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -59,6 +59,13 @@
     @test npoints(s) == 50
   end
 
+  @testset "filter" begin
+    𝒟 = georef((a=[1,2,3], b=[1,1,missing]))
+    𝒫 = filter(s -> !ismissing(s.b), 𝒟)
+    @test 𝒫[:a] == [1,2]
+    @test 𝒫[:b] == [1,1]
+  end
+
   @testset "uniquecoords" begin
     X = [i*j for i in 1:2, j in 1:1_000_000]
     z = rand(1_000_000)


### PR DESCRIPTION
Fixes https://github.com/JuliaEarth/GeoStats.jl/issues/101

We provide a new `PredicateFilter` that acts on the "rows" of the spatial data table. The PR also introduces a convenience function `filter(pred, sdata)` to follow Julia's builtin syntax.