### PR TITLE
Refact pointset

### DIFF
--- a/src/domains/point_set.jl
+++ b/src/domains/point_set.jl
@@ -27,7 +27,6 @@ julia> PointSet([(rand(),rand()) for i in 1:100])
 ```
 """
 struct PointSet{T,N} <: SpatialDomain{T,N}
-  # coords::Matrix{T}
   coords::Vector{SVector{N,T}} 
 
   function PointSet{T,N}(coords) where {N,T}

--- a/src/domains/point_set.jl
+++ b/src/domains/point_set.jl
@@ -26,15 +26,8 @@ struct PointSet{T,N} <: SpatialDomain{T,N}
   coords::Vector{SVector{N,T}} 
 end
 
-PointSet(coords::AbstractMatrix) = PointSet(collect(eachcol(coords)))
+PointSet(coords::AbstractMatrix) = PointSet(collect(SVector{size(coords,1)}.(eachcol(coords))))
 PointSet(coords::AbstractVector{<:NTuple}) = PointSet(SVector.(coords))
-
-function PointSet(coords::AbstractVector{<:AbstractVector})
-  @assert !isempty(coords) "coordinates must be non-empty"
-  @assert length(coords) > 0 "coordinates must contain one point at least"
-  N = length(coords[1]) #getting the dimensionality of the point
-  PointSet(SVector{N}.(coords))
-end
 
 nelms(ps::PointSet) = length(ps.coords)
 

--- a/src/domains/point_set.jl
+++ b/src/domains/point_set.jl
@@ -3,11 +3,12 @@
 # ------------------------------------------------------------------
 
 """
-PointSet(coords)
+    PointSet(coords)
 
-A set of points with coordinates coords. Each point is represented by a static vector
-or tuple. Alternatively, coords can be a matrix where the number of rows equals the
+A set of points with coordinates `coords`. Each point is represented by a static vector
+or tuple. Alternatively, `coords` can be a matrix where the number of rows equals the
 number of dimensions.
+
 ## Examples
 
 Create a 2D point set with 100 points:
@@ -47,6 +48,6 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ps::PointSet{T,N}) where {N,T}
   println(io, ps)
-  m = hcat(ps.coords...)
+  m = reduce(hcat, ps.coords) #hcat(ps.coords...)
   Base.print_array(io, m)
 end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -6,7 +6,7 @@
     @test coordinates(ps, 2) == [0., 1.]
 
     @test sprint(show, ps) == "2 PointSet{Float64,2}"
-    @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n 1.0  0.0\n 0.0  1.0"
+    @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n [1.0, 0.0]\n [0.0, 1.0]"
 
     if visualtests
       Random.seed!(2019)

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -1,25 +1,33 @@
 @testset "Domains" begin
   @testset "PointSet" begin
-    # same values, different representations
+    # testing different ways to build a PointSet results in the same PointSet
     ps1 = PointSet([1. 0.; 0. 1.])            # as matrix
     ps2 = PointSet([(1.0, 0.0), (0.0, 1.0)])  # as vector of tuples
-    for ps in [ps1, ps2]
-      @test nelms(ps) == 2
-      @test coordinates(ps, 1) == [1., 0.]
-      @test coordinates(ps, 2) == [0., 1.]
+    
+    @test ps1.coords == ps2.coords
 
-      @test sprint(show, ps) == "2 PointSet{Float64,2}"
-      @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n 1.0  0.0\n 0.0  1.0"
+    # building a PointSet of tuples with different lengths should fail
+    @test_throws MethodError PointSet([(1.0, 0.0), (0.0, 1.0 , 4.0)])
 
-      if visualtests
-        Random.seed!(2019)
-        @plottest plot(PointSet(rand(1,10))) joinpath(datadir,"pset1D.png") !istravis
-        @plottest plot(PointSet(rand(2,10))) joinpath(datadir,"pset2D.png") !istravis
-        @plottest plot(PointSet(rand(3,10))) joinpath(datadir,"pset3D.png") !istravis
-        @plottest plot(PointSet(rand(1,10)),1:10) joinpath(datadir,"pset1D-data.png") !istravis
-        @plottest plot(PointSet(rand(2,10)),1:10) joinpath(datadir,"pset2D-data.png") !istravis
-        @plottest plot(PointSet(rand(3,10)),1:10) joinpath(datadir,"pset3D-data.png") !istravis
-      end
+    # more tests 
+    ps = PointSet([1. 0.; 0. 1.])
+
+    @test nelms(ps) == 2
+    @test coordinates(ps, 1) == [1., 0.]
+    @test coordinates(ps, 2) == [0., 1.]
+
+    @test sprint(show, ps) == "2 PointSet{Float64,2}"
+    @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n 1.0  0.0\n 0.0  1.0"
+
+
+    if visualtests
+      Random.seed!(2019)
+      @plottest plot(PointSet(rand(1,10))) joinpath(datadir,"pset1D.png") !istravis
+      @plottest plot(PointSet(rand(2,10))) joinpath(datadir,"pset2D.png") !istravis
+      @plottest plot(PointSet(rand(3,10))) joinpath(datadir,"pset3D.png") !istravis
+      @plottest plot(PointSet(rand(1,10)),1:10) joinpath(datadir,"pset1D-data.png") !istravis
+      @plottest plot(PointSet(rand(2,10)),1:10) joinpath(datadir,"pset2D-data.png") !istravis
+      @plottest plot(PointSet(rand(3,10)),1:10) joinpath(datadir,"pset3D-data.png") !istravis
     end
   end
 

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -1,21 +1,25 @@
 @testset "Domains" begin
   @testset "PointSet" begin
-    ps = PointSet([1. 0.; 0. 1.])
-    @test nelms(ps) == 2
-    @test coordinates(ps, 1) == [1., 0.]
-    @test coordinates(ps, 2) == [0., 1.]
+    # same values, different representations
+    ps1 = PointSet([1. 0.; 0. 1.])            # as matrix
+    ps2 = PointSet([(1.0, 0.0), (0.0, 1.0)])  # as vector of tuples
+    for ps in [ps1, ps2]
+      @test nelms(ps) == 2
+      @test coordinates(ps, 1) == [1., 0.]
+      @test coordinates(ps, 2) == [0., 1.]
 
-    @test sprint(show, ps) == "2 PointSet{Float64,2}"
-    @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n [1.0, 0.0]\n [0.0, 1.0]"
+      @test sprint(show, ps) == "2 PointSet{Float64,2}"
+      @test sprint(show, MIME"text/plain"(), ps) == "2 PointSet{Float64,2}\n 1.0  0.0\n 0.0  1.0"
 
-    if visualtests
-      Random.seed!(2019)
-      @plottest plot(PointSet(rand(1,10))) joinpath(datadir,"pset1D.png") !istravis
-      @plottest plot(PointSet(rand(2,10))) joinpath(datadir,"pset2D.png") !istravis
-      @plottest plot(PointSet(rand(3,10))) joinpath(datadir,"pset3D.png") !istravis
-      @plottest plot(PointSet(rand(1,10)),1:10) joinpath(datadir,"pset1D-data.png") !istravis
-      @plottest plot(PointSet(rand(2,10)),1:10) joinpath(datadir,"pset2D-data.png") !istravis
-      @plottest plot(PointSet(rand(3,10)),1:10) joinpath(datadir,"pset3D-data.png") !istravis
+      if visualtests
+        Random.seed!(2019)
+        @plottest plot(PointSet(rand(1,10))) joinpath(datadir,"pset1D.png") !istravis
+        @plottest plot(PointSet(rand(2,10))) joinpath(datadir,"pset2D.png") !istravis
+        @plottest plot(PointSet(rand(3,10))) joinpath(datadir,"pset3D.png") !istravis
+        @plottest plot(PointSet(rand(1,10)),1:10) joinpath(datadir,"pset1D-data.png") !istravis
+        @plottest plot(PointSet(rand(2,10)),1:10) joinpath(datadir,"pset2D-data.png") !istravis
+        @plottest plot(PointSet(rand(3,10)),1:10) joinpath(datadir,"pset3D-data.png") !istravis
+      end
     end
   end
 


### PR DESCRIPTION
With this change some improvements are observed.

Current implementation using Matrix:
```

for i in 1:10
  solution = @time solve(problem, solver)
end
  4.042634 seconds (3.67 M allocations: 11.620 GiB, 6.44% gc time)
  4.037391 seconds (3.67 M allocations: 11.620 GiB, 5.93% gc time)
  4.064429 seconds (3.67 M allocations: 11.620 GiB, 5.65% gc time)
  4.116754 seconds (3.67 M allocations: 11.620 GiB, 5.33% gc time)
  4.125295 seconds (3.67 M allocations: 11.620 GiB, 5.17% gc time)
  4.235886 seconds (3.67 M allocations: 11.620 GiB, 8.01% gc time)
  4.095777 seconds (3.67 M allocations: 11.620 GiB, 4.67% gc time)
  4.114237 seconds (3.67 M allocations: 11.620 GiB, 4.70% gc time)
  4.185361 seconds (3.67 M allocations: 11.620 GiB, 4.85% gc time)
  4.126609 seconds (3.67 M allocations: 11.620 GiB, 4.42% gc time)
```

With the proposed implementation:

```
for i in 1:10
         @time solve(problem, solver)
       end
  3.248977 seconds (3.21 M allocations: 3.808 GiB, 3.70% gc time)
  3.346375 seconds (3.21 M allocations: 3.808 GiB, 3.55% gc time)
  3.371415 seconds (3.21 M allocations: 3.808 GiB, 3.62% gc time)
  3.399316 seconds (3.21 M allocations: 3.808 GiB, 3.56% gc time)
  3.378670 seconds (3.21 M allocations: 3.808 GiB, 3.47% gc time)
  3.336218 seconds (3.21 M allocations: 3.808 GiB, 3.49% gc time)
  3.237753 seconds (3.21 M allocations: 3.808 GiB, 3.42% gc time)
  3.343776 seconds (3.21 M allocations: 3.808 GiB, 5.58% gc time)
  3.266192 seconds (3.21 M allocations: 3.808 GiB, 3.17% gc time)
  3.287763 seconds (3.21 M allocations: 3.808 GiB, 3.37% gc time)
```

All tests (locally) passed OK.