### PR TITLE
Generalise NeighborhoodSearch

### DIFF
--- a/src/GeoStatsBase.jl
+++ b/src/GeoStatsBase.jl
@@ -15,7 +15,7 @@ using Distances: Metric, Euclidean, Mahalanobis, pairwise
 using Distributions: ContinuousUnivariateDistribution, median, mode
 using CategoricalArrays: CategoricalValue, CategoricalArray
 using CategoricalArrays: levels, isordered, pool, levelcode
-using NearestNeighbors: KDTree, knn, inrange
+using NearestNeighbors: KDTree, knn, inrange, BallTree
 using ReferenceFrameRotations: angle_to_dcm
 using DataFrames: DataFrame, DataFrame!
 using StaticArrays: SVector, MVector, SOneTo
@@ -38,6 +38,7 @@ import Distributions: quantile, cdf
 import ScientificTypes: Scitype, scitype
 import Distances: evaluate
 import DataFrames: groupby
+import NearestNeighbors: MinkowskiMetric
 
 # aliases
 const MI = MLJModelInterface

--- a/src/GeoStatsBase.jl
+++ b/src/GeoStatsBase.jl
@@ -15,7 +15,7 @@ using Distances: Metric, Euclidean, Mahalanobis, pairwise
 using Distributions: ContinuousUnivariateDistribution, median, mode
 using CategoricalArrays: CategoricalValue, CategoricalArray
 using CategoricalArrays: levels, isordered, pool, levelcode
-using NearestNeighbors: KDTree, knn, inrange, BallTree
+using NearestNeighbors: KDTree, BallTree, knn, inrange
 using ReferenceFrameRotations: angle_to_dcm
 using DataFrames: DataFrame, DataFrame!
 using StaticArrays: SVector, MVector, SOneTo

--- a/src/neighborsearch/neighborhood.jl
+++ b/src/neighborsearch/neighborhood.jl
@@ -19,7 +19,7 @@ end
 function NeighborhoodSearch(object::O, neigh::N) where {O,N}
   tree = if neigh isa BallNeighborhood
     metric(neigh) isa MinkowskiMetric ? KDTree(coordinates(object), metric(neigh)) :
-        BallTree(coordinates(object), metric(neigh))
+                                        BallTree(coordinates(object), metric(neigh))
   else
     nothing
   end

--- a/test/neighborsearch.jl
+++ b/test/neighborsearch.jl
@@ -21,6 +21,12 @@
     @test Set(n) == Set([81,82,91,92])
     n = GeoStatsBase.search([9.,9.], S)
     @test Set(n) == Set([89,90,99,100])
+
+# Non-MinkowskiMetric example
+    𝒟 = RegularGrid((360, 180), (0., -90.), (1., 1.))
+    S = NeighborhoodSearch(𝒟, BallNeighborhood(150., Haversine(6371.0)))
+    n = GeoStatsBase.search([0.,0.], S)
+    @test Set(n) == Set([32041, 32402, 32401, 32761, 32760])
   end
 
   @testset "KNearestSearch" begin


### PR DESCRIPTION
Generalises `NeighborhoodSearch` to work with a non-Minkowski metric by using a `BallTree`.
 Fixes JuliaEarth/GeoStats.jl#140.