### PR TITLE
New groupby implementation

### DIFF
--- a/src/GeoStatsBase.jl
+++ b/src/GeoStatsBase.jl
@@ -55,6 +55,7 @@ include("histograms.jl")
 include("rotations.jl")
 include("transforms.jl")
 include("ui.jl")
+include("deprecations.jl")
 
 export
   # data
@@ -165,7 +166,7 @@ export
   # utilities
   uniquecoords,
   integrate,
-  groupby,
+  @groupby,
 
   # rotations
   DatamineAngles,

--- a/src/GeoStatsBase.jl
+++ b/src/GeoStatsBase.jl
@@ -55,7 +55,6 @@ include("histograms.jl")
 include("rotations.jl")
 include("transforms.jl")
 include("ui.jl")
-include("deprecations.jl")
 
 export
   # data

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,5 +1,0 @@
-# ------------------------------------------------------------------
-# Licensed under the MIT License. See LICENSE in the project root.
-# ------------------------------------------------------------------
-
-@deprecate groupby(data::Data, var::Symbol) _groupby(data, var)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+@deprecate groupby(data::Data, var::Symbol) _groupby(data, var)

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -2,44 +2,27 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
-"""
-    groupby(data, var)
+macro groupby(data, cols...)
+  :(_groupby($(esc(data)), $(cols...)))
+end
 
-Partition spatial `data` into groups of constant value
-for spatial variable `var`.
+_groupby(data::Data, spec) = _groupby(data, colspec(spec))
+_groupby(data::Data, cols::T...) where {T<:Col} = 
+  _groupby(data, colspec(cols))
 
-### Notes
+function _groupby(data::Data, colspec::ColSpec)
+  table = values(data)
 
-Missing values are grouped into a separate group.
-"""
-function groupby(data::Data, var::Symbol)
-  vars = Tables.schema(values(data)).names
-  @assert var ∈ vars "invalid variable name"
+  cols   = Tables.columns(table)
+  names  = Tables.columnnames(cols)
+  snames = choose(colspec, names)
 
-  # data for variable
-  vdata = data[var]
+  scolumns = [Tables.getcolumn(cols, nm) for nm in snames]
 
-  # partition function with missings
-  function f(i, j)
-    vi, vj = vdata[i], vdata[j]
-    mi, mj = ismissing(vi), ismissing(vj)
-    (mi && mj) || ((!mi && !mj) && (vi == vj))
-  end
+  srows = collect(zip(scolumns...))
+  urows = unique(srows)
+  inds  = map(row -> findall(===(row), srows), urows)
 
-  # partition function without missings
-  g(i, j) = vdata[i] == vdata[j]
-
-  # select the appropriate predicate function
-  pred = Missing <: eltype(vdata) ? f : g
-
-  # perform partition
-  p = partition(data, PredicatePartition(pred))
-
-  # retrieve value from each subset
-  vals = [vdata[s[1]] for s in indices(p)]
-
-  # save metadata
-  metadata = Dict(:values => vals)
-
-  Partition(data, indices(p), metadata)
+  metadata = Dict(:values => urows)
+  Partition(data, inds, metadata)
 end

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -7,7 +7,7 @@
     @groupby(data, [col₁, col₂, ..., colₙ])
     @groupby(data, (col₁, col₂, ..., colₙ))
 
-Partition spatial `data` into groups of constant value
+Partition geospatial `data` into groups of constant value
 for selected columns `col₁`, `col₂`, ..., `colₙ`.
 
     @groupby(data, regex)

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -43,7 +43,7 @@ function _groupby(data::Data, colspec::ColSpec)
 
   srows = collect(zip(scolumns...))
   urows = unique(srows)
-  inds  = map(row -> findall(Base.Fix2(===, row), srows), urows)
+  inds  = map(row -> findall(isequal(row), srows), urows)
 
   metadata = Dict(:values => urows)
   Partition(data, inds, metadata)

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -12,8 +12,8 @@ for selected columns `col₁`, `col₂`, ..., `colₙ`.
 
     @groupby(data, regex)
 
-Partition spatial `data` into groups of constant value
-for columns that math with `regex`.
+Partition geospatial `data` into groups of constant value
+for columns that match with `regex`.
 
 # Examples
 

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -2,6 +2,28 @@
 # Licensed under the MIT License. See LICENSE in the project root.
 # ------------------------------------------------------------------
 
+"""
+    @groupby(data, col₁, col₂, ..., colₙ)
+    @groupby(data, [col₁, col₂, ..., colₙ])
+    @groupby(data, (col₁, col₂, ..., colₙ))
+
+Partition spatial `data` into groups of constant value
+for selected columns `col₁`, `col₂`, ..., `colₙ`.
+
+    @groupby(data, regex)
+
+Partition spatial `data` into groups of constant value
+for columns that math with `regex`.
+
+# Examples
+
+```julia
+@groupby(data, 1, 3, 5)
+@groupby(data, [:a, :c, :e])
+@groupby(data, ("a", "c", "e"))
+@groupby(data, r"[ace]")
+```
+"""
 macro groupby(data, cols...)
   :(_groupby($(esc(data)), $(cols...)))
 end
@@ -21,7 +43,7 @@ function _groupby(data::Data, colspec::ColSpec)
 
   srows = collect(zip(scolumns...))
   urows = unique(srows)
-  inds  = map(row -> findall(===(row), srows), urows)
+  inds  = map(row -> findall(Base.Fix2(===, row), srows), urows)
 
   metadata = Dict(:values => urows)
   Partition(data, inds, metadata)

--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -7,13 +7,11 @@
     @groupby(data, [col₁, col₂, ..., colₙ])
     @groupby(data, (col₁, col₂, ..., colₙ))
 
-Partition geospatial `data` into groups of constant value
-for selected columns `col₁`, `col₂`, ..., `colₙ`.
+Partition geospatial `data` according to selected columns `col₁`, `col₂`, ..., `colₙ`.
 
     @groupby(data, regex)
 
-Partition geospatial `data` into groups of constant value
-for columns that match with `regex`.
+Partition geospatial `data` according to columns that match with `regex`.
 
 # Examples
 
@@ -24,7 +22,7 @@ for columns that match with `regex`.
 @groupby(data, r"[ace]")
 ```
 """
-macro groupby(data, cols...)
+macro groupby(data::Symbol, cols...)
   :(_groupby($(esc(data)), $(cols...)))
 end
 
@@ -40,8 +38,8 @@ function _groupby(data::Data, colspec::ColSpec)
   snames = choose(colspec, names)
 
   scolumns = [Tables.getcolumn(cols, nm) for nm in snames]
+  srows    = collect(zip(scolumns...))
 
-  srows = collect(zip(scolumns...))
   urows = unique(srows)
   inds  = map(row -> findall(isequal(row), srows), urows)
 

--- a/test/geoops.jl
+++ b/test/geoops.jl
@@ -21,11 +21,8 @@
   end
 
   @testset "groupby" begin
-    # deprecated
-    setify(lists) = Set(Set.(lists))
-
     d = georef((z=[1,2,3],x=[4,5,6]), rand(2,3))
-    g = groupby(d, :z)
+    g = @groupby(d, :z)
     @test all(nelements.(g) .== 1)
     rows = [[1 4], [2 5], [3 6]]
     for i in 1:3
@@ -34,14 +31,14 @@
 
     z = vec([1 1 1; 2 2 2; 3 3 3])
     sdata = georef((z=z,), CartesianGrid(3,3))
-    p = groupby(sdata, :z)
-    @test setify(indices(p)) == setify([[1,4,7],[2,5,8],[3,6,9]])
+    p = @groupby(sdata, :z)
+    @test indices(p) == [[1,4,7],[2,5,8],[3,6,9]]
 
     # groupby with missing values
     z = vec([missing 1 1; 2 missing 2; 3 3 missing])
     sdata = georef((z=z,), CartesianGrid(3,3))
-    p = groupby(sdata, :z)
-    @test setify(indices(p)) == setify([[4,7],[2,8],[3,6],[1,5,9]])
+    p = @groupby(sdata, :z)
+    @test indices(p) == [[1,5,9],[2,8],[3,6],[4,7]]
 
     # macro
     x = [1, 1, 1, 1, 2, 2, 2, 2]
@@ -53,35 +50,35 @@
     # args...
     # integers
     p = @groupby(sdata, 1)
-    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    @test indices(p) == [[1,2,3,4],[5,6,7,8]]
     # symbols
     p = @groupby(sdata, :y)
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
     # strings
     p = @groupby(sdata, "x", "y")
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
     # vector...
     # integers
     p = @groupby(sdata, [1])
-    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    @test indices(p) == [[1,2,3,4],[5,6,7,8]]
     # symbols
     p = @groupby(sdata, [:y])
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
     # strings
     p = @groupby(sdata, ["x", "y"])
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
     # tuple...
     # integers
     p = @groupby(sdata, (1,))
-    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    @test indices(p) == [[1,2,3,4],[5,6,7,8]]
     # symbols
     p = @groupby(sdata, (:y,))
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
     # strings
     p = @groupby(sdata, ("x", "y"))
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
     # missing values
     x = [1, 1, missing, missing, 2, 2, 2, 2]
@@ -91,9 +88,9 @@
     sdata = georef(table, rand(2, 8))
 
     p = @groupby(sdata, :x)
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6,7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6,7,8]]
     p = @groupby(sdata, :x, :y)
-    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
     # isequal
     x = [0.0, 0, 0, -0.0, 2, 2, 2, 2]
@@ -103,9 +100,9 @@
     sdata = georef(table, rand(2, 8))
 
     p = @groupby(sdata, :x)
-    @test setify(indices(p)) == setify([[1,2,3],[4],[5,6,7,8]])
+    @test indices(p) == [[1,2,3],[4],[5,6,7,8]]
     p = @groupby(sdata, :x, :y)
-    @test setify(indices(p)) == setify([[1,2],[3],[4],[5,6],[7,8]])
+    @test indices(p) == [[1,2],[3],[4],[5,6],[7,8]]
   end
 
   @testset "filter" begin

--- a/test/geoops.jl
+++ b/test/geoops.jl
@@ -21,6 +21,7 @@
   end
 
   @testset "groupby" begin
+    # deprecated
     setify(lists) = Set(Set.(lists))
 
     d = georef((z=[1,2,3],x=[4,5,6]), rand(2,3))
@@ -41,6 +42,70 @@
     sdata = georef((z=z,), CartesianGrid(3,3))
     p = groupby(sdata, :z)
     @test setify(indices(p)) == setify([[4,7],[2,8],[3,6],[1,5,9]])
+
+    # macro
+    x = [1, 1, 1, 1, 2, 2, 2, 2]
+    y = [1, 1, 2, 2, 3, 3, 4, 4]
+    z = [1, 2, 3, 4, 5, 6, 7, 8]
+    table = (; x, y, z)
+    sdata = georef(table, rand(2, 8))
+
+    # args...
+    # integers
+    p = @groupby(sdata, 1)
+    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    # symbols
+    p = @groupby(sdata, :y)
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    # strings
+    p = @groupby(sdata, "x", "y")
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+
+    # vector...
+    # integers
+    p = @groupby(sdata, [1])
+    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    # symbols
+    p = @groupby(sdata, [:y])
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    # strings
+    p = @groupby(sdata, ["x", "y"])
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+
+    # tuple...
+    # integers
+    p = @groupby(sdata, (1,))
+    @test setify(indices(p)) == setify([[1,2,3,4],[5,6,7,8]])
+    # symbols
+    p = @groupby(sdata, (:y,))
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+    # strings
+    p = @groupby(sdata, ("x", "y"))
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+
+    # missing values
+    x = [1, 1, missing, missing, 2, 2, 2, 2]
+    y = [1, 1, 2, 2, 3, 3, missing, missing]
+    z = [1, 2, 3, 4, 5, 6, 7, 8]
+    table = (; x, y, z)
+    sdata = georef(table, rand(2, 8))
+
+    p = @groupby(sdata, :x)
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6,7,8]])
+    p = @groupby(sdata, :x, :y)
+    @test setify(indices(p)) == setify([[1,2],[3,4],[5,6],[7,8]])
+
+    # isequal
+    x = [0.0, 0, 0, -0.0, 2, 2, 2, 2]
+    y = [1, 1, 2, 2, 3, 3, 4, 4]
+    z = [1, 2, 3, 4, 5, 6, 7, 8]
+    table = (; x, y, z)
+    sdata = georef(table, rand(2, 8))
+
+    p = @groupby(sdata, :x)
+    @test setify(indices(p)) == setify([[1,2,3],[4],[5,6,7,8]])
+    p = @groupby(sdata, :x, :y)
+    @test setify(indices(p)) == setify([[1,2],[3],[4],[5,6],[7,8]])
   end
 
   @testset "filter" begin


### PR DESCRIPTION
This PR adds a new implementation for `groupby`.
Now `groupby` is a macro that supports grouping Mashes.Data objects in more than one column.
Column selection is now provided by the `ColSpec` interface.