### PR TITLE
Add variable interpolation to `@groupby` macro

### DIFF
--- a/src/geoops/groupby.jl
+++ b/src/geoops/groupby.jl
@@ -23,7 +23,12 @@ Partition geospatial `data` according to columns that match with `regex`.
 ```
 """
 macro groupby(data::Symbol, cols...)
-  :(_groupby($(esc(data)), $(cols...)))
+  spec = Expr(:tuple, esc.(cols)...)
+  :(_groupby($(esc(data)), $spec))
+end
+
+macro groupby(data::Symbol, spec)
+  :(_groupby($(esc(data)), $(esc(spec))))
 end
 
 _groupby(data::Data, spec) = _groupby(data, colspec(spec))

--- a/test/geoops.jl
+++ b/test/geoops.jl
@@ -80,6 +80,10 @@
     p = @groupby(sdata, ("x", "y"))
     @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
+    # regex
+    p = @groupby(sdata, r"[xy]")
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+
     # missing values
     x = [1, 1, missing, missing, 2, 2, 2, 2]
     y = [1, 1, 2, 2, 3, 3, missing, missing]
@@ -103,6 +107,27 @@
     @test indices(p) == [[1,2,3],[4],[5,6,7,8]]
     p = @groupby(sdata, :x, :y)
     @test indices(p) == [[1,2],[3],[4],[5,6],[7,8]]
+
+    # variable interpolation
+    x = [1, 1, 1, 1, 2, 2, 2, 2]
+    y = [1, 1, 2, 2, 3, 3, 4, 4]
+    z = [1, 2, 3, 4, 5, 6, 7, 8]
+    table = (; x, y, z)
+    sdata = georef(table, rand(2, 8))
+
+    cols = (:x, :y)
+    p = @groupby(sdata, cols)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, cols...)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+
+    c1, c2 = :x, :y
+    p = @groupby(sdata, c1, c2)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, [c1, c2])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, (c1, c2))
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
   end
 
   @testset "filter" begin

--- a/test/geoops.jl
+++ b/test/geoops.jl
@@ -84,6 +84,21 @@
     p = @groupby(sdata, r"[xy]")
     @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
 
+    # variable interpolation
+    cols = (:x, :y)
+    p = @groupby(sdata, cols)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, cols...)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+
+    c1, c2 = :x, :y
+    p = @groupby(sdata, c1, c2)
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, [c1, c2])
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+    p = @groupby(sdata, (c1, c2))
+    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
+
     # missing values
     x = [1, 1, missing, missing, 2, 2, 2, 2]
     y = [1, 1, 2, 2, 3, 3, missing, missing]
@@ -107,27 +122,6 @@
     @test indices(p) == [[1,2,3],[4],[5,6,7,8]]
     p = @groupby(sdata, :x, :y)
     @test indices(p) == [[1,2],[3],[4],[5,6],[7,8]]
-
-    # variable interpolation
-    x = [1, 1, 1, 1, 2, 2, 2, 2]
-    y = [1, 1, 2, 2, 3, 3, 4, 4]
-    z = [1, 2, 3, 4, 5, 6, 7, 8]
-    table = (; x, y, z)
-    sdata = georef(table, rand(2, 8))
-
-    cols = (:x, :y)
-    p = @groupby(sdata, cols)
-    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
-    p = @groupby(sdata, cols...)
-    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
-
-    c1, c2 = :x, :y
-    p = @groupby(sdata, c1, c2)
-    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
-    p = @groupby(sdata, [c1, c2])
-    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
-    p = @groupby(sdata, (c1, c2))
-    @test indices(p) == [[1,2],[3,4],[5,6],[7,8]]
   end
 
   @testset "filter" begin


### PR DESCRIPTION
This PR adds variable interpolation support for the `@groupby` macro.
Now it is possible to write code like this:
```julia
cols = (:x, :y)
@groupby(data, cols)
@groupby(data, cols...)

c1, c2 = :x, :y
@groupby(data, c1, c2)
@groupby(data, [c1, c2])
@groupby(data, (c1, c2))
```