### PR TITLE
fix typos

### DIFF
--- a/src/errors/drv.jl
+++ b/src/errors/drv.jl
@@ -5,7 +5,7 @@
 """
     DensityRatioValidation(k; [parameters])
 
-Desntity ratio validation where weights are first obtained with density
+Density ratio validation where weights are first obtained with density
 ratio estimation, and then used in `k`-fold weighted cross-validation.
 
 ## Parameters

--- a/src/errors/wcv.jl
+++ b/src/errors/wcv.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 
 """
-    WeightedValidation(weigthing, folding; lambda=1.0, loss=Dict())
+    WeightedValidation(weighting, folding; lambda=1.0, loss=Dict())
 
 An error estimation method which samples are weighted with
 `weighting` method and split into folds with `folding` method.

--- a/src/geoops/transform.jl
+++ b/src/geoops/transform.jl
@@ -10,7 +10,7 @@ and new columns `col₁`, `col₂`, ..., `colₙ` defined by expressions
 `expr₁`, `expr₂`, ..., `exprₙ`. The `object` can be a `Data` object
 or a `Partition` object returned by the `@groupby` macro.
 In each expression the `object` columns are represented by symbols 
-and the functions use `broadcast` by default. Also, is pissible pass strings 
+and the functions use `broadcast` by default. Also, is possible pass strings 
 or variables as column names using the `{colname}` syntax. If there are columns 
 in the table with the same name as the new columns, these will be replaced.
 

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -122,7 +122,7 @@ with the simulation `solver`, optionally using preprocessed data in `preproc`.
 
 By implementing this function instead of `solve`, the developer is
 informing the framework that realizations generated with his/her
-solver are indenpendent one from another. GeoStats.jl will trigger
+solver are independent one from another. GeoStats.jl will trigger
 the algorithm in parallel (if enough processes are available).
 """
 function solvesingle end

--- a/test/geoops.jl
+++ b/test/geoops.jl
@@ -195,7 +195,7 @@
     ndata = @transform(sdata, :dist_to_origin = dist(:geometry))
     @test ndata.dist_to_origin == dist.(domain(sdata))
 
-    # replece :geometry column
+    # replace :geometry column
     testfunc(point) = Point(coordinates(point) .+ 1)
     ndata = @transform(sdata, :geometry = testfunc(:geometry))
     @test domain(ndata) == GeometrySet(testfunc.(domain(sdata)))


### PR DESCRIPTION
src/errors/drv.jl
src/errors/wcv.jl
src/geoops/transform.jl
src/solvers.jl
test/geoops.jl

this pull concludes typo fixes for the "split into various packages" packages under

[Project organization](https://juliaearth.github.io/GeoStats.jl/stable/#Project-organization)

per request I can review those listed other packages "separately for additional functionality"